### PR TITLE
Added support for switching input devices (i.e. microphones)

### DIFF
--- a/CommunicationDeviceSwitcherService.ApplicationServices/DefaultCommunicateDeviceSwitchNotificationClient.cs
+++ b/CommunicationDeviceSwitcherService.ApplicationServices/DefaultCommunicateDeviceSwitchNotificationClient.cs
@@ -25,6 +25,12 @@ namespace CommunicationDeviceSwitcherService.ApplicationServices
                     var deviceId = defaultDeviceId;
                     _policyConfig.SetDefaultEndpoint(deviceId, Role.Communications);
                 }
+                else if (dataFlow == DataFlow.Capture && deviceRole == Role.Multimedia)
+                {
+                    var deviceId = defaultDeviceId;
+                    _policyConfig.SetDefaultEndpoint(deviceId, Role.Communications);
+                }
+
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This piece of code checks if the default capture/input device is being changed, and automatically sets it as the default communication input device accordingly.

It has worked on all my tested systems, but it's worth testing it on your own before accepting the pull request.